### PR TITLE
Update Hibernate config to persist database to disk

### DIFF
--- a/docs-web/src/dev/resources/.gitignore
+++ b/docs-web/src/dev/resources/.gitignore
@@ -1,0 +1,2 @@
+database.mv.db
+database.trace.db

--- a/docs-web/src/dev/resources/hibernate.properties
+++ b/docs-web/src/dev/resources/hibernate.properties
@@ -1,5 +1,5 @@
 hibernate.connection.driver_class=org.h2.Driver
-hibernate.connection.url=jdbc:h2:mem:docs
+hibernate.connection.url=jdbc:h2:./src/dev/resources/database
 hibernate.connection.username=sa
 hibernate.connection.password=
 hibernate.hbm2ddl.auto=


### PR DESCRIPTION
Before applying this change, the default Hibernate configuration uses an in-memory database. The result of this is that all changes are lost (i.e., there is no persistence!) between stopping and restarting the server. This change updates Hibernate to use a simple embedded database file that persists between runs of the server.