### PR TITLE
Resolves #11: Improving SEO score by fixing empty hrefs

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -179,7 +179,7 @@
         </div>
         <ul class="list-inline">
           <li uib-dropdown class="dropdown">
-            <a href uib-dropdown-toggle>
+            <span uib-dropdown-toggle>
               <span ng-switch="currentLang">
                 <span ng-switch-when="en">English</span>
                 <span ng-switch-when="fr">Français</span>
@@ -193,18 +193,18 @@
                 <span ng-switch-when="zh_TW">繁體中文</span>
               </span>
               <span class="caret"></span>
-            </a>
+            </span>
             <ul class="dropdown-menu">
-              <li><a href ng-click="changeLanguage('en')" ng-class="{ 'bg-info': currentLang == 'en' }">English</a></li>
-              <li><a href ng-click="changeLanguage('fr')" ng-class="{ 'bg-info': currentLang == 'fr' }">Français</a></li>
-              <li><a href ng-click="changeLanguage('de')" ng-class="{ 'bg-info': currentLang == 'de' }">Deutsch</a></li>
-              <li><a href ng-click="changeLanguage('it')" ng-class="{ 'bg-info': currentLang == 'it' }">Italiano</a></li>
-              <li><a href ng-click="changeLanguage('es')" ng-class="{ 'bg-info': currentLang == 'es' }">Española</a></li>
-              <li><a href ng-click="changeLanguage('el')" ng-class="{ 'bg-info': currentLang == 'el' }">Ελληνικά</a></li>
-              <li><a href ng-click="changeLanguage('ru')" ng-class="{ 'bg-info': currentLang == 'ru' }">Pусский</a></li>
-              <li><a href ng-click="changeLanguage('pl')" ng-class="{ 'bg-info': currentLang == 'pl' }">Polski</a></li>              
-			        <li><a href ng-click="changeLanguage('zh_CN')" ng-class="{ 'bg-info': currentLang == 'zh_CN' }">简体中文</a></li>
-              <li><a href ng-click="changeLanguage('zh_TW')" ng-class="{ 'bg-info': currentLang == 'zh_TW' }">繁體中文</a></li>
+              <li><span ng-click="changeLanguage('en')" ng-class="{ 'bg-info': currentLang == 'en' }">English</span></li>
+              <li><span ng-click="changeLanguage('fr')" ng-class="{ 'bg-info': currentLang == 'fr' }">Français</span></li>
+              <li><span ng-click="changeLanguage('de')" ng-class="{ 'bg-info': currentLang == 'de' }">Deutsch</span></li>
+              <li><span ng-click="changeLanguage('it')" ng-class="{ 'bg-info': currentLang == 'it' }">Italiano</span></li>
+              <li><span ng-click="changeLanguage('es')" ng-class="{ 'bg-info': currentLang == 'es' }">Española</span></li>
+              <li><span ng-click="changeLanguage('el')" ng-class="{ 'bg-info': currentLang == 'el' }">Ελληνικά</span></li>
+              <li><span ng-click="changeLanguage('ru')" ng-class="{ 'bg-info': currentLang == 'ru' }">Pусский</span></li>
+              <li><span ng-click="changeLanguage('pl')" ng-class="{ 'bg-info': currentLang == 'pl' }">Polski</span></li>              
+			        <li><span ng-click="changeLanguage('zh_CN')" ng-class="{ 'bg-info': currentLang == 'zh_CN' }">简体中文</span></li>
+              <li><span ng-click="changeLanguage('zh_TW')" ng-class="{ 'bg-info': currentLang == 'zh_TW' }">繁體中文</span></li>
             </ul>
           </li>
           <li translate="document.default.footer_sismics"></li>

--- a/docs-web/src/main/webapp/src/partial/docs/login.html
+++ b/docs-web/src/main/webapp/src/partial/docs/login.html
@@ -69,7 +69,7 @@
 
             <div class="col-md-6 text-right btn-password-lost">
               <div class="well-sm">
-                <a href ng-click="openPasswordLost()">{{ 'login.password_lost_btn' | translate }}</a>
+                <a href="#/login" ng-click="openPasswordLost()">{{ 'login.password_lost_btn' | translate }}</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
To fix this issue, I replaced all of the `a` tags in index.html with `span` tags, and removed the `hrefs` as well. This change was made because these links are for the language dropdown and thus do not need to be `a` tags and have an `href`. Additionally, I added a link to the login page in login.html to the "Password lost?" link, which allows Google to crawl the website and improve SEO.

As a result of these efforts, the SEO improved from a 70 to an 80, according to the Google Lighthouse testing report.