### PR TITLE
Add empty alt text to img element used as decoration

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/login.html
+++ b/docs-web/src/main/webapp/src/partial/docs/login.html
@@ -29,7 +29,7 @@
   <div class="col-sm-6 col-xs-12 login-box">
     <div class="row">
       <div class="col-lg-offset-4 col-lg-4 col-xs-offset-1 col-xs-10">
-        <img src="img/title.png" class="img-responsive" />
+        <img src="img/title.png" class="img-responsive" alt=""/>
 
         <form>
           <div class="form-group">


### PR DESCRIPTION
This pull request resolves #6. The change made was adding an `alt=""` attribute to the `img` element in `login.html`. Since the `img` element is used as a decorator, no `alt` text is necessary, thus I set the `alt` attribute to the empty string.

This improved the accessibility score by 9 points from 86 to 95.