### PR TITLE
Add a meta description

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="renderer" content="webkit" />
+    <meta name="description" content="Teedy is a lightweight document management system packed with all the features you can expect from big expensive solutions but still easy to use." />
     <link rel="shortcut icon" href="../api/theme/image/logo" />
     <link rel="manifest" href="manifest.json" />
     <!-- ref:css style/style.min.css?@build.date@ -->


### PR DESCRIPTION
This PR resolves #18 by adding a [meta description](https://web.dev/meta-description/) to the Teedy web pages.

This makes the Lighthouse SEO score go from 70% to 80% (for the login page on desktop).