### PR TITLE
Darken text colors for better contrast ratio

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -127,7 +127,7 @@
 
         <a class="navbar-brand" href="#">
           <span ng-if="appName == 'Teedy'">
-            <span style="color: #2aabd2;">teedy</span>
+            <span style="color: #337ab7;">teedy</span>
           </span>
           <span ng-if="appName != 'Teedy'" style="color: #888;">{{ appName }}</span>
         </a>

--- a/docs-web/src/main/webapp/src/style/bootstrap.css
+++ b/docs-web/src/main/webapp/src/style/bootstrap.css
@@ -526,7 +526,7 @@ mark,
   text-transform: capitalize;
 }
 .text-muted {
-  color: #777;
+  color: #555;
 }
 .text-primary {
   color: #337ab7;
@@ -3897,7 +3897,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 .pagination > .disabled > a,
 .pagination > .disabled > a:hover,
 .pagination > .disabled > a:focus {
-  color: #777;
+  color: #555;
   cursor: not-allowed;
   background-color: #fff;
   border-color: #ddd;

--- a/docs-web/src/main/webapp/src/style/main.less
+++ b/docs-web/src/main/webapp/src/style/main.less
@@ -461,14 +461,14 @@ input[readonly].share-link {
   right: 0;
   top: 200px;
   transform: rotate(-90deg) translateY(-100%);
-  background: #ccc;
+  background: #555;
   padding: 8px;
   color: #fff;
   font-weight: bold;
   transform-origin: 100% 0;
 
   &:hover {
-    background: #aaa;
+    background: #000;
     text-decoration: none;
     color: #fff;
   }
@@ -693,7 +693,7 @@ input[readonly].share-link {
 .navbar-default .navbar-nav > .active > a,
 .navbar-default .navbar-nav > .active > a:hover,
 .navbar-default .navbar-nav > .active > a:focus {
-  color: #2ab2dc;
+  color: #337ab7;
   background: none;
 }
 


### PR DESCRIPTION
The colors of the light blue and grey text/figures are darkened to improve the contrast ratio, and thus the accessibility score. This has been tested locally and improved accessibility from 80 to 84.  