### PR TITLE
Fixed Tappable Button Sizes

### DIFF
--- a/docs-web/src/main/webapp/src/style/bootstrap.css
+++ b/docs-web/src/main/webapp/src/style/bootstrap.css
@@ -1818,6 +1818,7 @@ input[type="search"] {
 }
 .radio,
 .checkbox {
+  padding: 18px 18px 18px; 
   position: relative;
   display: block;
   margin-top: 10px;
@@ -2689,6 +2690,8 @@ tbody.collapse.in {
 .dropup,
 .dropdown {
   position: relative;
+  padding-top: 18px;
+  padding-bottom: 18px;
 }
 .dropdown-toggle:focus {
   outline: 0;


### PR DESCRIPTION
After increasing the padding to the language dropdown menu and the 'Remember me' check box to meet the recommended 48px by 48px tap box, the SEO score improved to 67.

Resolves [#37](https://github.com/CMU-313/Teedy/issues/37) 