### PR TITLE
Add [lang] attribute to html tag

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="docs">
+<html ng-app="docs" lang="en">
   <head>
     <title ng-bind-template="{{ pageTitle ? pageTitle : appName }}">Teedy</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />


### PR DESCRIPTION
This PR resolves [#43](https://github.com/CMU-313/Teedy/issues/43) by adding a [lang](https://web.dev/html-has-lang/?utm_source=lighthouse&utm_medium=devtools) attribute to the Teedy web pages.

This makes the Lighthouse Accessibility score go from 80% to 82% (for the home page /document)