### PR TITLE
Added alt text to teedy image to improve SEO

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/login.html
+++ b/docs-web/src/main/webapp/src/partial/docs/login.html
@@ -29,7 +29,7 @@
   <div class="col-sm-6 col-xs-12 login-box">
     <div class="row">
       <div class="col-lg-offset-4 col-lg-4 col-xs-offset-1 col-xs-10">
-        <img src="img/title.png" class="img-responsive" />
+        <img alt="Teedy Title Image" src="img/title.png" class="img-responsive" />
 
         <form>
           <div class="form-group">


### PR DESCRIPTION
This PR increases the SEO from 70 to 80 by adding alt text to the Teedy image on the login page.