### PR TITLE
added [lang] attribute to <html> element for Tag page

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="docs">
+<html ng-app="docs" lang="en">
   <head>
     <title ng-bind-template="{{ pageTitle ? pageTitle : appName }}">Teedy</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />


### PR DESCRIPTION
Currently, the Accessibility score for the Tags page is 86. One of the issues that contributes to this low score is that the page doesn't specify a lang attribute. To increase the Accessibility score, I added the lang attribute to the Tags page. This sets the language of the document to English for the screen reader to know.

Resolves #60 