### PR TITLE
added explicit height and width for the Teedy logo on the login page

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/login.html
+++ b/docs-web/src/main/webapp/src/partial/docs/login.html
@@ -29,7 +29,7 @@
   <div class="col-sm-6 col-xs-12 login-box">
     <div class="row">
       <div class="col-lg-offset-4 col-lg-4 col-xs-offset-1 col-xs-10">
-        <img src="img/title.png" class="img-responsive" />
+        <img src="img/title.png" class="img-responsive" width="278" height="116"/>
 
         <form>
           <div class="form-group">


### PR DESCRIPTION
The current metric score for Performance is 46. One reason is because there is no width and height specified on the Teedy logo image which means Cumulative Layout Shift (CLS) is not optimized and may result in large layout shifts as the page loads.