### PR TITLE
added meta description to documents page

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="renderer" content="webkit" />
+     <meta name="description" content="Documents page that is used for uploaded, searching, and
+adding new documents"/>
     <link rel="shortcut icon" href="../api/theme/image/logo" />
     <link rel="manifest" href="manifest.json" />
     <!-- ref:css style/style.min.css?@build.date@ -->


### PR DESCRIPTION
After adding a meta description to the documents page, the SEO score for the documents page increased from 78 to 89. This resolves issue #52 .