### PR TITLE
Added alt attribute to image elements

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/login.html
+++ b/docs-web/src/main/webapp/src/partial/docs/login.html
@@ -29,7 +29,7 @@
   <div class="col-sm-6 col-xs-12 login-box">
     <div class="row">
       <div class="col-lg-offset-4 col-lg-4 col-xs-offset-1 col-xs-10">
-        <img src="img/title.png" class="img-responsive" />
+        <img src="img/title.png" class="img-responsive" alt="Teedy title image"/>
 
         <form>
           <div class="form-group">


### PR DESCRIPTION
Added an alt attribute that described the Teedy Title logo image to the image element. This fixed the issue where image elements did not have alt attributes.
Raised the accessibility score from 86 to 95. 