### PR TITLE
Added discernible link names to home and document link buttons on Documents page

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -95,7 +95,10 @@
     <script src="app/docs/controller/settings/SettingsVocabulary.js" type="text/javascript"></script>
     <script src="app/docs/controller/settings/SettingsMetadata.js" type="text/javascript"></script>
     <script src="app/docs/controller/settings/SettingsLdap.js" type="text/javascript"></script>
-    <script src="app/docs/controller/usergroup/UserGroup.js" type="text/javascript"></script>
+    <script src="app/docs/controller/usergroup/UserGroup.js" type="text/javascript">
+      <meta name="description" content="Lookup page for users and groups with
+      access to the same documents on the Teedy management platform system."/>
+    </script>
     <script src="app/docs/controller/usergroup/UserProfile.js" type="text/javascript"></script>
     <script src="app/docs/controller/usergroup/GroupProfile.js" type="text/javascript"></script>
     <script src="app/docs/service/User.js" type="text/javascript"></script>

--- a/docs-web/src/main/webapp/src/partial/docs/document.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.html
@@ -162,7 +162,7 @@
 
       <!-- Navigation breadcrumb -->
       <ol class="breadcrumb breadcrumb-navigation pull-left mt-10">
-        <li><a href ng-click="navigateToTag()"><span class="fas fa-home"></span></a></li>
+        <li><a href ng-click="navigateToTag()"><span class="fas fa-home"></span>Home</a></li>
         <li ng-repeat="tag in getCurrentNavigation()" ng-class="{ active: tag.id == navigatedTag.id }">
           <a class="label" ng-style="{ 'background-color': tag.color }" ng-if="tag.id != navigatedTag.id" href ng-click="navigateToTag(tag)">{{ tag.name }}</a>
           <span class="label" ng-style="{ 'background-color': tag.color }" ng-if="tag.id == navigatedTag.id">{{ tag.name }}</span>
@@ -253,7 +253,7 @@
             {{ document.title }} ({{ document.file_count }})
             <span class="fas fa-share" ng-if="document.shared" uib-tooltip="{{ 'document.shared' | translate }}"></span>
             <span class="fas fa-random" ng-if="document.active_route" uib-tooltip="{{ document.current_step_name }}"></span>
-            <a href="#/document/view/{{ document.id }}" target="_blank" ng-click="$event.stopPropagation()"><span class="fas fa-link"></span></a>
+            <a href="#/document/view/{{ document.id }}" target="_blank" ng-click="$event.stopPropagation()"><span class="fas fa-link"></span>Document Link</a>
 
             <div class="pull-right text-muted small" uib-tooltip="{{ 'document.last_updated' | translate: { date: document.update_date } }}">
               {{ document.create_date | timeAgo: dateFormat }}

--- a/docs-web/src/main/webapp/src/partial/docs/usergroup.html
+++ b/docs-web/src/main/webapp/src/partial/docs/usergroup.html
@@ -1,3 +1,8 @@
+<!-- <head>
+  <meta name="description" content="Lookup page for users and groups with
+  access to the same documents on the Teedy management platform system."/>
+</head> -->
+
 <div class="row">
   <div class="col-md-4">
     <div class="well well-3d">


### PR DESCRIPTION
Resolves issue https://github.com/CMU-313/Teedy/issues/55 regarding the Documents page. Accessibility score increases from 82 to 84. The button that links to the home page is named "Home" and the button that links to the uploaded document is named "Document Link"