### PR TITLE
Added labels to input in metadata table in custom metadata configuration settings

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/settings.metadata.html
+++ b/docs-web/src/main/webapp/src/partial/docs/settings.metadata.html
@@ -55,7 +55,9 @@
       <tbody>
       <tr ng-repeat="meta in metadata">
         <td>
+          <label>
           <input type="text" class="form-control" ng-model="meta.name" maxlength="50" ng-blur="updateMetadata(meta)" />
+          </label>
         </td>
         <td>
           {{ meta.type }}


### PR DESCRIPTION
Resolves #75 
 
The change that was made was to add labels to the input of the metadata table, which is in the custom metadata configuration section in settings. The form elements needed to have associated labels, so this edit was able to resolve this issue. This edit increased the Accessibility score from 83 to 91.

Lighthouse Test Before Edit:
<img width="1416" alt="Before Edit" src="https://user-images.githubusercontent.com/79665965/188053647-1b439268-a1d6-429a-ae40-feb8734cb853.png">


Lighthouse Test After Edit:
<img width="1424" alt="After Edit" src="https://user-images.githubusercontent.com/79665965/188053665-3fea933e-ee76-4895-9fc7-2d335a91059e.png">

 