### PR TITLE
Added name and alt attributes to image element on login page

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/login.html
+++ b/docs-web/src/main/webapp/src/partial/docs/login.html
@@ -29,7 +29,7 @@
   <div class="col-sm-6 col-xs-12 login-box">
     <div class="row">
       <div class="col-lg-offset-4 col-lg-4 col-xs-offset-1 col-xs-10">
-        <img src="img/title.png" class="img-responsive" />
+        <img src="img/title.png" class="img-responsive" name="teedy" alt="teedy"/>
 
         <form>
           <div class="form-group">


### PR DESCRIPTION
Resolves Issue #81 

Added the [name] and [alt] attributes to the title image on the login page. Both fields were set to the text on the title image. The warning was resolved and the SEO score improved from 70% to 80% (for the login page).