### PR TITLE
Added button names to Add Document page

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/document.edit.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.edit.html
@@ -48,7 +48,7 @@
                    ng-model="document.create_date" datepicker-options="{ startingDay: 1, showWeeks: false }"
                    is-open="datepickerOpened" ng-disabled="fileIsUploading" />
             <span class="input-group-btn">
-              <button type="button" class="btn btn-default" ng-click="datepickerOpened = true" ng-disabled="fileIsUploading"><i class="fas fa-calendar"></i></button>
+              <button type="button" class="btn btn-default" ng-click="datepickerOpened = true" ng-disabled="fileIsUploading" aria-label="Calendar"><i class="fas fa-calendar"></i></button>
             </span>
           </div>
         </div>

--- a/docs-web/src/main/webapp/src/partial/docs/document.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.html
@@ -7,7 +7,7 @@
           <a href="#/document/add" class="btn btn-primary">
             <span class="fas fa-plus"></span> {{ 'document.add_document' | translate }}
           </a>
-          <button type="button" class="btn btn-primary" uib-dropdown-toggle>
+          <button type="button" class="btn btn-primary" uib-dropdown-toggle aria-label="Dropdown toggle">
             <span class="caret"></span>
           </button>
           <ul uib-dropdown-menu>
@@ -197,13 +197,15 @@
         <button class="btn btn-default" ng-click="navigationToggle()"
                 ng-class="{ active: navigationEnabled }"
                 uib-tooltip="{{ 'document.toggle_navigation' | translate }}"
-                tooltip-append-to-body="true">
+                tooltip-append-to-body="true"
+                aria-label="Toggle folder navigation">
           <span class="far" ng-class="{ 'fa-folder-open': navigationEnabled, 'fa-folder': !navigationEnabled }"></span>
         </button>
         <!-- Add a tag here -->
         <button class="btn btn-primary btn-add-tag"
                 uib-tooltip="{{ 'tag.new_tag' | translate }}"
-                ng-click="addTagHere()">
+                ng-click="addTagHere()"
+                aria-label="New tag">
           <span>
             <i class="fas fa-tag"></i>
             <i class="fas fa-plus"></i>


### PR DESCRIPTION
In this PR, I resolved #97 by adding button names to the Add Documents page using the `aria-label` attribute for buttons. The Accessibility score improved from 82 to 88 after these changes.

Lighthouse report before:
<img width="504" alt="Screen Shot 2022-09-02 at 8 44 49 PM" src="https://user-images.githubusercontent.com/67844715/188250422-e1531e6a-fd5b-4c1b-927e-1a4588c5608b.png">

Lighthouse report after:
<img width="499" alt="Screen Shot 2022-09-02 at 8 43 54 PM" src="https://user-images.githubusercontent.com/67844715/188250429-c0f80263-ab25-4a43-ab06-e0ac3d0e059d.png">