### PR TITLE
Added aria-label values to the button fields on both the tag creation and tag edit partials

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/tag.edit.html
+++ b/docs-web/src/main/webapp/src/partial/docs/tag.edit.html
@@ -23,7 +23,7 @@
       <div class="col-sm-2">
         <div class="input-group" id="inputColor" ng-class="{ 'has-error': !editTagForm.color.$valid && tagForm.$dirty }">
           <span colorpicker class="input-group-addon btn btn-default" data-color="#3a87ad" ng-model="tag.color" ng-style="{ 'background': tag.color }">&nbsp;</span>
-          <button class="btn btn-default" ng-click="hexaField = true" ng-show="!hexaField"><span class="fas fa-microchip"></span></button>
+          <button class="btn btn-default" ng-click="hexaField = true" ng-show="!hexaField" aria-label="Hex Color"><span class="fas fa-microchip"></span></button>
           <input type="text" name="color" class="form-control" ng-maxlength="7" ng-model="tag.color" ng-show="hexaField">
         </div>
       </div>

--- a/docs-web/src/main/webapp/src/partial/docs/tag.html
+++ b/docs-web/src/main/webapp/src/partial/docs/tag.html
@@ -15,9 +15,9 @@
     <div class="well well-3d">
       <form class="form-inline text-center" name="tagForm" novalidate>
         <div class="input-group" ng-class="{ 'has-error': !tagForm.color.$valid && tagForm.$dirty }">
-          <span colorpicker class="input-group-addon btn btn-default" data-color="#3a87ad" ng-model="tag.color" ng-style="{ 'background': tag.color }">&nbsp;</span>
+          <span colorpicker class="input-group-addon btn btn-default" data-color="#3a87ad" ng-model="tag.color" ng-style="{ 'background': tag.color }" aria-label="Hex Color">&nbsp;</span>
           <input type="text" name="color" class="form-control" ng-maxlength="7" ng-model="tag.color" ng-show="hexaField">
-          <button class="btn btn-default" ng-click="hexaField = true" ng-show="!hexaField"><span class="fas fa-microchip"></span></button>
+          <button class="btn btn-default" ng-click="hexaField = true" ng-show="!hexaField" aria-label="Hex Color"><span class="fas fa-microchip"></span></button>
         </div>
         <div class="form-group" ng-class="{ 'has-error': !tagForm.name.$valid && tagForm.$dirty }">
           <input type="text" name="name" ng-attr-placeholder="{{ 'tag.new_tag' | translate }}" class="form-control"


### PR DESCRIPTION
The "edit tag" page underwent an Accessibility score increase by 7 points, from 79 to 86, as a result of giving the buttons descriptive names utilizing the aria-label tags as suggested by [web.dev](https://web.dev/button-name/). Labels now accurately reflect what the button is adjusting (hex value associated with the tag being edited). Resolves #72.