### PR TITLE
Resolves #116: Improve Accessibility by Fixing Poorly-structured Lists in Setting

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/settings.html
+++ b/docs-web/src/main/webapp/src/partial/docs/settings.html
@@ -3,25 +3,51 @@
     <div class="panel panel-default">
       <div class="panel-heading"><strong>{{ 'settings.menu_personal_settings' | translate }}</strong></div>
       <ul class="list-group">
-        <a class="list-group-item" ui-sref-active="{ active: 'settings.account.**' }" href="#/settings/account">{{ 'settings.menu_user_account' | translate }}</a>
-        <a class="list-group-item" ui-sref-active="{ active: 'settings.security.**' }" href="#/settings/security">{{ 'settings.menu_two_factor_auth' | translate }}</a>
-        <a class="list-group-item" ui-sref-active="{ active: 'settings.session.**' }" href="#/settings/session">{{ 'settings.menu_opened_sessions' | translate }}</a>
-        <a class="list-group-item" ui-sref-active="{ active: 'settings.fileimporter.**' }" href="#/settings/fileimporter">{{ 'settings.menu_file_importer' | translate }}</a>
+        <li>
+          <a class="list-group-item" ui-sref-active="{ active: 'settings.account.**' }" href="#/settings/account">{{ 'settings.menu_user_account' | translate }}</a>
+        </li>
+        <li>
+          <a class="list-group-item" ui-sref-active="{ active: 'settings.security.**' }" href="#/settings/security">{{ 'settings.menu_two_factor_auth' | translate }}</a>
+        </li>
+        <li>
+          <a class="list-group-item" ui-sref-active="{ active: 'settings.session.**' }" href="#/settings/session">{{ 'settings.menu_opened_sessions' | translate }}</a>
+        </li>
+        <li>
+          <a class="list-group-item" ui-sref-active="{ active: 'settings.fileimporter.**' }" href="#/settings/fileimporter">{{ 'settings.menu_file_importer' | translate }}</a>
+        </li>
       </ul>
     </div>
 
     <div class="panel panel-default" ng-show="isAdmin">
       <div class="panel-heading"><strong>{{ 'settings.menu_general_settings' | translate }}</strong></div>
       <ul class="list-group">
-        <a class="list-group-item" ui-sref-active="{ active: 'settings.workflow.**' }" href="#/settings/workflow">{{ 'settings.menu_workflow' | translate }}</a>
-        <a class="list-group-item" ui-sref-active="{ active: 'settings.user.**' }" href="#/settings/user">{{ 'settings.menu_users' | translate }}</a>
-        <a class="list-group-item" ui-sref-active="{ active: 'settings.group.**' }" href="#/settings/group">{{ 'settings.menu_groups' | translate }}</a>
-        <a class="list-group-item" ui-sref-active="{ active: 'settings.vocabulary.**' }" href="#/settings/vocabulary">{{ 'settings.menu_vocabularies' | translate }}</a>
-        <a class="list-group-item" ui-sref-active="{ active: 'settings.config.**' }" href="#/settings/config">{{ 'settings.menu_configuration' | translate }}</a>
-        <a class="list-group-item" ui-sref-active="{ active: 'settings.metadata.**' }" href="#/settings/metadata">{{ 'settings.menu_metadata' | translate }}</a>
-        <a class="list-group-item" ui-sref-active="{ active: 'settings.inbox.**' }" href="#/settings/inbox">{{ 'settings.menu_inbox' | translate }}</a>
-        <a class="list-group-item" ui-sref-active="{ active: 'settings.ldap.**' }" href="#/settings/ldap">{{ 'settings.menu_ldap' | translate }}</a>
-        <a class="list-group-item" ui-sref-active="{ active: 'settings.monitoring.**' }" href="#/settings/monitoring">{{ 'settings.menu_monitoring' | translate }}</a>
+        <li>
+          <a class="list-group-item" ui-sref-active="{ active: 'settings.workflow.**' }" href="#/settings/workflow">{{ 'settings.menu_workflow' | translate }}</a>
+        </li>
+        <li>
+          <a class="list-group-item" ui-sref-active="{ active: 'settings.user.**' }" href="#/settings/user">{{ 'settings.menu_users' | translate }}</a>
+        </li>
+        <li>
+          <a class="list-group-item" ui-sref-active="{ active: 'settings.group.**' }" href="#/settings/group">{{ 'settings.menu_groups' | translate }}</a>
+        </li>
+        <li>
+          <a class="list-group-item" ui-sref-active="{ active: 'settings.vocabulary.**' }" href="#/settings/vocabulary">{{ 'settings.menu_vocabularies' | translate }}</a>
+        </li>
+        <li>
+          <a class="list-group-item" ui-sref-active="{ active: 'settings.config.**' }" href="#/settings/config">{{ 'settings.menu_configuration' | translate }}</a>
+        </li>
+        <li>
+          <a class="list-group-item" ui-sref-active="{ active: 'settings.metadata.**' }" href="#/settings/metadata">{{ 'settings.menu_metadata' | translate }}</a>
+        </li>
+        <li>
+          <a class="list-group-item" ui-sref-active="{ active: 'settings.inbox.**' }" href="#/settings/inbox">{{ 'settings.menu_inbox' | translate }}</a>
+        </li>
+        <li>
+          <a class="list-group-item" ui-sref-active="{ active: 'settings.ldap.**' }" href="#/settings/ldap">{{ 'settings.menu_ldap' | translate }}</a>
+        </li>
+        <li>
+          <a class="list-group-item" ui-sref-active="{ active: 'settings.monitoring.**' }" href="#/settings/monitoring">{{ 'settings.menu_monitoring' | translate }}</a>
+        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
I fixed the poorly-structured unordered lists in Setting. There was an accessibility warning because the elements directly in <ul> were <a>. I put all the hyperlinks into <li> </li> and fixed this problem. 
The accessibility score reported by Google Lighthouse has increased from 90 to 93. 