### PR TITLE
Added labels to inputs for settings/vocabulary

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/settings.vocabulary.html
+++ b/docs-web/src/main/webapp/src/partial/docs/settings.vocabulary.html
@@ -26,10 +26,16 @@
       <tbody>
         <tr class="info">
           <td>
-            <input type="text" ng-attr-placeholder="{{ 'settings.vocabulary.new_entry' | translate }}" class="form-control" ng-model="entry.value" maxlength="500" />
+            <label>
+              Vocab New Entry Value
+              <input type="text" ng-attr-placeholder="{{ 'settings.vocabulary.new_entry' | translate }}" class="form-control" ng-model="entry.value" maxlength="500" />
+            </label>
           </td>
           <td>
-            <input type="number" class="form-control" ng-model="entry.order" />
+            <label>
+              Vocab New Entry Order
+              <input type="number" class="form-control" ng-model="entry.order" />
+            </label>
           </td>
           <td>
             <span ng-click="addEntry(entry)" class="fas fa-plus pointer"></span>
@@ -40,10 +46,16 @@
         </tr>
         <tr ng-repeat="entry in entries | orderBy: 'order'">
           <td>
-            <input type="text" class="form-control" ng-model="entry.value" maxlength="500" ng-blur="updateEntry(entry)" />
+            <label>
+              Vocab Update Entry Value
+              <input type="text" class="form-control" ng-model="entry.value" maxlength="500" ng-blur="updateEntry(entry)" />
+            </label>
           </td>
           <td>
-            <input type="number" class="form-control" ng-model="entry.order" ng-blur="updateEntry(entry)" />
+            <label>
+              Vocab Update Entry Order
+              <input type="number" class="form-control" ng-model="entry.order" ng-blur="updateEntry(entry)" />
+            </label>
           </td>
           <td>
             <span ng-click="deleteEntry(entry)" class="fas fa-trash pointer"></span>


### PR DESCRIPTION
Resolves #124 

This pull request resolves the issue that occurs on the settings --> vocabulary page saying that "Form elements do not have associated labels" by including such labels for inputs. This change improved the Accessibility score from 82 to 90 on Lighthouse.

Before adding labels to inputs on the settings/vocabulary page the Accessibility score was an 82 as seen below:
<img width="1430" alt="Screen Shot 2022-09-04 at 1 35 46 PM" src="https://user-images.githubusercontent.com/59752837/188328543-c8e4be06-e126-498e-af0d-2b551f667907.png">

After adding the appropriate labels to inputs, the Accessibility score increased to 90 and the warning "Form elements do not have associated labels" went away as shown below:
<img width="1429" alt="Screen Shot 2022-09-04 at 1 44 01 PM" src="https://user-images.githubusercontent.com/59752837/188328584-98ffaf40-59cf-47de-8cb8-e33352fbc212.png">

