### PR TITLE
Fix settings targets

### DIFF
--- a/docs-web/src/main/webapp/src/style/bootstrap.css
+++ b/docs-web/src/main/webapp/src/style/bootstrap.css
@@ -2258,8 +2258,6 @@ fieldset[disabled] a.btn {
   color: #333;
   background-color: #e6e6e6;
   border-color: #adadad;
-  height: 48px;
-  width: 48px;
 }
 .btn-default:active:hover,
 .btn-default.active:hover,

--- a/docs-web/src/main/webapp/src/style/bootstrap.css
+++ b/docs-web/src/main/webapp/src/style/bootstrap.css
@@ -2689,6 +2689,7 @@ tbody.collapse.in {
 .dropup,
 .dropdown {
   position: relative;
+  padding: 20px 20px;
 }
 .dropdown-toggle:focus {
   outline: 0;

--- a/docs-web/src/main/webapp/src/style/bootstrap.css
+++ b/docs-web/src/main/webapp/src/style/bootstrap.css
@@ -2689,7 +2689,7 @@ tbody.collapse.in {
 .dropup,
 .dropdown {
   position: relative;
-  padding: 20px 20px;
+  padding: 20px 21px;
 }
 .dropdown-toggle:focus {
   outline: 0;

--- a/docs-web/src/main/webapp/src/style/bootstrap.css
+++ b/docs-web/src/main/webapp/src/style/bootstrap.css
@@ -2689,7 +2689,7 @@ tbody.collapse.in {
 .dropup,
 .dropdown {
   position: relative;
-  padding: 20px 21px;
+  padding: 20px 20px;
 }
 .dropdown-toggle:focus {
   outline: 0;

--- a/docs-web/src/main/webapp/src/style/bootstrap.css
+++ b/docs-web/src/main/webapp/src/style/bootstrap.css
@@ -2258,6 +2258,8 @@ fieldset[disabled] a.btn {
   color: #333;
   background-color: #e6e6e6;
   border-color: #adadad;
+  height: 48px;
+  width: 48px;
 }
 .btn-default:active:hover,
 .btn-default.active:hover,

--- a/docs-web/src/main/webapp/src/style/pell.css
+++ b/docs-web/src/main/webapp/src/style/pell.css
@@ -17,9 +17,10 @@
   background-color: transparent;
   border: none;
   cursor: pointer;
-  height: 48px;
+  height: 1px;
   outline: 0;
-  width: 48px;
+  width: 1px;
+  padding: 10px;
   vertical-align: bottom; }
 
 .pell-button-selected {

--- a/docs-web/src/main/webapp/src/style/pell.css
+++ b/docs-web/src/main/webapp/src/style/pell.css
@@ -17,9 +17,9 @@
   background-color: transparent;
   border: none;
   cursor: pointer;
-  height: 30px;
+  height: 48px;
   outline: 0;
-  width: 30px;
+  width: 48px;
   vertical-align: bottom; }
 
 .pell-button-selected {

--- a/docs-web/src/main/webapp/src/style/pell.css
+++ b/docs-web/src/main/webapp/src/style/pell.css
@@ -17,10 +17,9 @@
   background-color: transparent;
   border: none;
   cursor: pointer;
-  height: 1px;
+  height: 30px;
   outline: 0;
-  width: 1px;
-  padding: 10px;
+  width: 30px;
   vertical-align: bottom; }
 
 .pell-button-selected {


### PR DESCRIPTION
Resolves #122 

To improve the SEO score, I added padding to the dropdown menu (now at 20px) so that 100% of tap targets will be at the appropriate size. This increased the SEO score from 80 to 82. 