### PR TITLE
added description to index and tag pages

### DIFF
--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
@@ -674,7 +674,7 @@ public class DocumentResource extends BaseResource {
     /**
      * Creates a new document.
      *
-     * @api {put} /document Add a document
+     * @api {put} /document 
      * @apiName PutDocument
      * @apiGroup Document
      * @apiParam {String} title Title

--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="renderer" content="webkit" />
+    <meta name="description" content="Welcome to Teedy!">
     <link rel="shortcut icon" href="../api/theme/image/logo" />
     <link rel="manifest" href="manifest.json" />
     <!-- ref:css style/style.min.css?@build.date@ -->

--- a/docs-web/src/main/webapp/src/partial/docs/tag.html
+++ b/docs-web/src/main/webapp/src/partial/docs/tag.html
@@ -1,3 +1,9 @@
+<!DOCTYPE html>
+<head>
+  <title>Tag Page</title>
+  <meta name="description" content="Teedy: Add a tag to the document.">
+</head>
+
 <script type="text/ng-template" id="tag-tree-item">
   <span ng-class="{ active: $stateParams.id == tag.id }">
     <span class="fas fa-tag" ng-style="{ 'color': tag.color }"></span>


### PR DESCRIPTION
Resolved #129 

In order to improve SEO score, I added a meta description to both the index and tag pages of Teedy. This was a suggestion given by Google Lighthouse, as adding a meta description allows for the webpage to be more easily-identified in searches. 

The SEO score improved from 79 to 89, as shown in the screenshots below. 
<img width="541" alt="Screen Shot 2022-09-04 at 17 21 20" src="https://user-images.githubusercontent.com/79778718/188334176-3336c4fc-e47e-4307-ac8f-f347f3f42702.png">
<img width="543" alt="Screen Shot 2022-09-04 at 17 22 16" src="https://user-images.githubusercontent.com/79778718/188334180-d85093cc-b557-433c-94bf-99978e50518a.png">
