### PR TITLE
added 8px of margin for buttons which had previously overlapped

### DIFF
--- a/docs-web/src/main/webapp/src/style/bootstrap.css
+++ b/docs-web/src/main/webapp/src/style/bootstrap.css
@@ -628,6 +628,7 @@ ol ol {
   display: inline-block;
   padding-right: 5px;
   padding-left: 5px;
+  margin: 8px; 
 }
 dl {
   margin-top: 0;
@@ -2842,7 +2843,7 @@ tbody.collapse.in {
 .btn-group .btn + .btn-group,
 .btn-group .btn-group + .btn,
 .btn-group .btn-group + .btn-group {
-  margin-left: -1px;
+  margin-left: 8px;
 }
 .btn-toolbar {
   margin-left: -5px;
@@ -3890,6 +3891,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
   cursor: default;
   background-color: #337ab7;
   border-color: #337ab7;
+  margin: 8px;
 }
 .pagination > .disabled > span,
 .pagination > .disabled > span:hover,
@@ -3901,6 +3903,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
   cursor: not-allowed;
   background-color: #fff;
   border-color: #ddd;
+  margin: 8px; 
 }
 .pagination-lg > li > a,
 .pagination-lg > li > span {


### PR DESCRIPTION
Resolves #24. This change ensures that no buttons are overlapping by increasing the margins to 8px of previously overlapping buttons. This improved the SEO score from 88 to 91 and improved the appropriately sized tap targets from 80% to 100%. 