### PR TITLE
add lang attribute to the index page

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="docs">
+<html ng-app="docs" lang="en">
   <head>
     <title ng-bind-template="{{ pageTitle ? pageTitle : appName }}">Teedy</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />


### PR DESCRIPTION
Resolves #9 
In the index.html file, changed <html ng-app="docs"> to <html ng-app="docs" lang="en">. By doing so, explicitly set the language of the home page to english.
The accessibility score of the home page improved from 86 to 89 due to this change.
