### PR TITLE
Resolves #76: improve code coverage in VocabularyResource

### DIFF
--- a/docs-web/pom.xml
+++ b/docs-web/pom.xml
@@ -139,6 +139,17 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>javax</groupId>
+      <artifactId>javaee-api</artifactId>
+      <version>8.0.1</version>
+    </dependency>
+  
+    <dependency>
+      <groupId>org.resthub</groupId>
+      <artifactId>resthub-web-common</artifactId>
+      <version>2.2.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/docs-web/src/test/java/com/sismics/docs/rest/TestVocabularyResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestVocabularyResource.java
@@ -5,6 +5,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import javax.json.JsonObject;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.Response;
@@ -108,5 +110,115 @@ public class TestVocabularyResource extends BaseJerseyTest {
                 .cookie(TokenBasedSecurityFilter.COOKIE_NAME, vocabulary1Token)
                 .get(JsonObject.class);
         Assert.assertEquals(0, json.getJsonArray("entries").size());
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testNullResourceUpdateThrowsException() {  
+        // Login admin
+        String adminToken = clientUtil.login("admin", "admin", false);
+
+        // Update a non-existant vocabulary entry with admin
+        target().path("/vocabulary/null").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .post(Entity.form(new Form()
+                        .param("name", "-")
+                        .param("value", "-")
+                        .param("order", "1")), JsonObject.class);
+    }
+
+    @Test
+    public void testNullParameterUpdateMakesNoChange() {
+        // Login admin
+        String adminToken = clientUtil.login("admin", "admin", false);
+
+        // Create a vocabulary entry with admin
+        JsonObject json = target().path("/vocabulary").request()
+        .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+        .put(Entity.form(new Form()
+                .param("name", "test-voc-2")
+                .param("value", "Second value")
+                .param("order", "1")), JsonObject.class);
+        String vocabulary1Id = json.getString("id");
+        // Update a vocabulary entry with null parameters using admin
+        json = target().path("/vocabulary/" + vocabulary1Id).request()
+        .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+        .post(Entity.form(new Form()
+                .param("name", null)
+                .param("value", null)
+                .param("order", null)), JsonObject.class);
+        Assert.assertEquals(vocabulary1Id, json.getString("id"));
+        // Expect no change
+        Assert.assertEquals("test-voc-2", json.getString("name"));
+        Assert.assertEquals("Second value", json.getString("value"));
+        Assert.assertEquals(1, json.getJsonNumber("order").intValue());
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testNullResourceDeleteThrowsException() {  
+        // Login admin
+        String adminToken = clientUtil.login("admin", "admin", false);
+
+        // Delete a non-existant vocabulary entry with admin
+        target().path("/vocabulary/null").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .delete(JsonObject.class);
+    }
+
+    @Test(expected = ForbiddenException.class)
+    public void testUnauthenticatedUserGetThrowsException() {
+        // Login admin
+        String adminToken = clientUtil.login("admin", "admin", false);
+        // Logout to invalidate token
+        clientUtil.logout(adminToken);
+
+        // Get vocabularies entries
+        target().path("/vocabulary/test").request()
+        .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+        .get(JsonObject.class);
+    }
+
+    @Test(expected = ForbiddenException.class)
+    public void testUnauthenticatedUserAddThrowsException() {
+        // Login admin
+        String adminToken = clientUtil.login("admin", "admin", false);
+        // Logout to invalidate token
+        clientUtil.logout(adminToken);
+
+        // Create a vocabulary entry
+        target().path("/vocabulary").request()
+                .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+                .put(Entity.form(new Form()
+                        .param("name", "unauthenticated")
+                        .param("value", "value")
+                        .param("order", "3")), JsonObject.class);
+    }
+
+    @Test(expected = ForbiddenException.class)
+    public void testUnauthenticatedUserUpdateThrowsException() {
+        // Login admin
+        String adminToken = clientUtil.login("admin", "admin", false);
+        // Logout to invalidate token
+        clientUtil.logout(adminToken);
+
+        // Update a vocabulary entry 
+        target().path("/vocabulary/test-voc-1").request()
+        .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+        .post(Entity.form(new Form()
+                .param("name", "test-voc-1-updated")
+                .param("value", "First value updated")
+                .param("order", "1")), JsonObject.class);
+    }
+
+    @Test(expected = ForbiddenException.class)
+    public void testUnauthenticatedUserDeleteThrowsException() {
+        // Login admin
+        String adminToken = clientUtil.login("admin", "admin", false);
+        // Logout to invalidate token
+        clientUtil.logout(adminToken);
+
+        // Delete a vocabulary entry 
+        target().path("/vocabulary/test-voc-1-updated").request()
+        .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+        .delete(JsonObject.class);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,26 @@
         <artifactId>jetty-maven-plugin</artifactId>
         <version>${org.eclipse.jetty.jetty-maven-plugin.version}</version>
       </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.8</version>
+        <executions>
+          <execution>
+            <goals>
+                <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+              <id>report</id>
+              <phase>test</phase>
+              <goals>
+                  <goal>report</goal>
+              </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
         


### PR DESCRIPTION
This PR resolves #76. It adds test cases to cover unauthenticated users attempting to get, update, add to, or delete vocabulary resources. It also adds tests for updating or deleting a resource that does not exist and updating a resource with null parameters making no change. The branch coverage has increased from 54% to 100%. 

![vocabulary_resource_coverage_fixed](https://user-images.githubusercontent.com/56098501/188357226-24fd7b63-9071-4e0a-881f-1a1d0e967c20.png)
