### PR TITLE
Removed collapse class from navbar to allow screen readers access navbar elements

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -133,7 +133,7 @@
         </a>
       </div>
 
-      <div class="collapse navbar-collapse" uib-collapse="isCollapsed">
+      <div class="navbar-collapse" uib-collapse="isCollapsed">
         <ul class="nav navbar-nav" ng-show="!userInfo.anonymous">
           <li ui-sref-active="{ active: 'document.**' }">
             <a href="#/document"><span class="fas fa-book"></span> {{ 'index.nav_documents' | translate }}</a>


### PR DESCRIPTION
Resolves #84 

Removed the collapse class from a <div> element within the navbar to make the navbar elements visible to screen readers. Focusable elements whose parent element had aria-hidden = "true" are now accessible by screen readers. Ultimately, the accessibility score improved from 84 to 86.