### PR TITLE
Added alt text to the Teedy logo image on login page

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/login.html
+++ b/docs-web/src/main/webapp/src/partial/docs/login.html
@@ -29,7 +29,7 @@
   <div class="col-sm-6 col-xs-12 login-box">
     <div class="row">
       <div class="col-lg-offset-4 col-lg-4 col-xs-offset-1 col-xs-10">
-        <img src="img/title.png" class="img-responsive" />
+        <img src="img/title.png" class="img-responsive" alt="Teedy logo"/>
 
         <form>
           <div class="form-group">


### PR DESCRIPTION
This pull request addresses issue #59. 

The change includes adding an [alt] attrubute to the title img tag in login.html. Since the image is a logo (non-decorative), alt text is necessary to communicate this. I decided to include both the company name and the word 'logo' in my description.

This change increased the accessibility score from 86 to 95 (9 points).