### PR TITLE
Added meta to index, settings, settings/config page

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="renderer" content="webkit" />
+    <meta name="description" content="Teedy is an open source, lightweight document management system for individuals and businesses."/>
     <link rel="shortcut icon" href="../api/theme/image/logo" />
     <link rel="manifest" href="manifest.json" />
     <!-- ref:css style/style.min.css?@build.date@ -->

--- a/docs-web/src/main/webapp/src/partial/docs/settings.config.html
+++ b/docs-web/src/main/webapp/src/partial/docs/settings.config.html
@@ -1,3 +1,9 @@
+<!DOCTYPE html>
+<head>
+  <title>Settings Configuration Page</title>
+  <meta name="description" content="Configuration settings page that chooses default language, theme customization, email configuration, and webhooks"/>
+</head>
+
 <h2>
   <span translate="settings.config.title_guest_access"></span>
   <span class="label" ng-class="{ 'label-success': app.guest_login, 'label-danger': !app.guest_login }">

--- a/docs-web/src/main/webapp/src/partial/docs/settings.html
+++ b/docs-web/src/main/webapp/src/partial/docs/settings.html
@@ -1,3 +1,9 @@
+<!DOCTYPE html>
+<head>
+  <title>Settings Page</title>
+  <meta name="description" content="Teedy settings homepage"/>
+</head>
+
 <div class="row">
   <div class="col-md-3 settings-menu">
     <div class="panel panel-default">


### PR DESCRIPTION
Closes #155 

Added meta description to briefly describe the settings/config page, along with index and settings page, as noted by Google Lighthouse, to increase the SEO score from 78 to 89.

<img width="500" alt="Screen Shot 2022-09-05 at 3 38 31 PM" src="https://user-images.githubusercontent.com/94236416/188506000-b83d5601-54d2-4808-a5f5-b965a1590699.png">