### PR TITLE
Resolves issue #101: Improve Accessibility score by adding [lang=en] to the html root element

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="docs">
+<html ng-app="docs" lang="en">
   <head>
     <title ng-bind-template="{{ pageTitle ? pageTitle : appName }}">Teedy</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />


### PR DESCRIPTION
Resolved #101 .
The google lighthouse score for Accessbility increases from 89 to 92 after adding `lang = "en"` to the html root element.
<img width="362" alt="Screenshot 2022-09-05 171902" src="https://user-images.githubusercontent.com/105766629/188515120-7e2b37c8-5028-44f4-98b6-9c335406f0bd.png">
