### PR TITLE
Improved branch coverage for ThemeResource

### DIFF
--- a/docs-web/src/test/java/com/sismics/docs/rest/TestThemeResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestThemeResource.java
@@ -9,6 +9,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import javax.json.JsonObject;
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
@@ -103,5 +104,22 @@ public class TestThemeResource extends BaseJerseyTest {
         // Get the background
         response = target().path("/theme/image/background").request().get();
         Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void testThemeResourceNullParameters() throws Exception {
+        // Login admin
+        String adminToken = clientUtil.login("admin", "admin", false);
+
+        // Update theme without setting params (null)
+        target().path("/theme").request()
+        .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+        .post(Entity.form(new Form()), JsonObject.class);
+
+        // Get the theme configuration
+        JsonObject json = target().path("/theme").request()
+                .get(JsonObject.class);
+        Assert.assertEquals("Teedy", json.getString("name"));
+        Assert.assertEquals("#ffffff", json.getString("color"));
     }
 }

--- a/docs-web/src/test/java/com/sismics/docs/rest/TestThemeResource.java
+++ b/docs-web/src/test/java/com/sismics/docs/rest/TestThemeResource.java
@@ -122,4 +122,18 @@ public class TestThemeResource extends BaseJerseyTest {
         Assert.assertEquals("Teedy", json.getString("name"));
         Assert.assertEquals("#ffffff", json.getString("color"));
     }
+
+    @Test(expected = ForbiddenException.class)
+    public void testThemeResourceUnauthenticatedPost() throws Exception {
+        // Login admin
+        String adminToken = clientUtil.login("admin", "admin", false);
+
+        // Logout admin
+        clientUtil.logout(adminToken);
+
+        // Update theme (post)
+        target().path("/theme").request()
+        .cookie(TokenBasedSecurityFilter.COOKIE_NAME, adminToken)
+        .post(Entity.form(new Form()), JsonObject.class);
+    }
 }


### PR DESCRIPTION
This pull request resolves #169 

With this PR, the overall branch coverage for ThemeResource increases from 57% to 85%. More specifically, the theme() method now has a branch coverage of 100% (it was 50%). The two new tests, testThemeResourceNullParameters and testThemeResourceUnauthenticatedPost, test the cases where color/name is not defined (null) and the user is unauthenticated (by logging out).   

