### PR TITLE
Added meta tag to index and settings inbox pages

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -2,6 +2,9 @@
 <html ng-app="docs">
   <head>
     <title ng-bind-template="{{ pageTitle ? pageTitle : appName }}">Teedy</title>
+    <meta name="description" content="Teedy is a lightweight document management system 
+                                      packed with all the features you can expect from
+                                      big expensive solutions but still easy to use.">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/docs-web/src/main/webapp/src/partial/docs/settings.inbox.html
+++ b/docs-web/src/main/webapp/src/partial/docs/settings.inbox.html
@@ -1,3 +1,7 @@
+<head>
+  <meta name="description" content="Inbox scanning page located in Settings.">
+</head>
+
 <h2>
   <span translate="settings.inbox.title"></span>
   <span class="label" ng-show="inbox"


### PR DESCRIPTION
Resolved #150 
Added meta description to the index and settings inbox pages affecting the Inbox scanning page. After these changes, the SEO score on Lighthouse went up from 78 to 89.

After:
![SEOScoreChange](https://user-images.githubusercontent.com/98036446/188545169-c75d0408-236d-4ceb-a4c5-4cf75dde7f3c.JPG)
Before:
![SEOScoreOG](https://user-images.githubusercontent.com/98036446/188545196-e6c93a99-9aad-4b1c-a411-eb6b4acd9feb.JPG)
