### PR TITLE
Improve SEO score for settings/monitoring page

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="renderer" content="webkit" />
+    <meta name="description" content="home page">
     <link rel="shortcut icon" href="../api/theme/image/logo" />
     <link rel="manifest" href="manifest.json" />
     <!-- ref:css style/style.min.css?@build.date@ -->

--- a/docs-web/src/main/webapp/src/partial/docs/settings.config.html
+++ b/docs-web/src/main/webapp/src/partial/docs/settings.config.html
@@ -1,3 +1,9 @@
+<!DOCTYPE html>
+<head>
+  <title>Settings Config Page</title>
+  <meta name="description" content="config page for settings for Teedy"/>
+</head>
+
 <h2>
   <span translate="settings.config.title_guest_access"></span>
   <span class="label" ng-class="{ 'label-success': app.guest_login, 'label-danger': !app.guest_login }">

--- a/docs-web/src/main/webapp/src/partial/docs/settings.html
+++ b/docs-web/src/main/webapp/src/partial/docs/settings.html
@@ -1,3 +1,9 @@
+<!DOCTYPE html>
+<head>
+  <title>Settings Page</title>
+  <meta name="description" content="settings page"/>
+</head>
+
 <div class="row">
   <div class="col-md-3 settings-menu">
     <div class="panel panel-default">

--- a/docs-web/src/main/webapp/src/partial/docs/settings.monitoring.html
+++ b/docs-web/src/main/webapp/src/partial/docs/settings.monitoring.html
@@ -1,3 +1,10 @@
+<!DOCTYPE html>
+<head>
+  <title>Settings Monitoring Page</title>
+  <meta name="description" content="Settings monitoring page is for managing queued tasks.">
+</head>
+
+</meta name="description" content="settings monitoring background tasks">
 <h2 translate="settings.monitoring.background_tasks"></h2>
 <p>
   <strong>{{ 'settings.monitoring.queued_tasks' | translate: { count: app.queued_tasks } }}</strong>
@@ -6,6 +13,7 @@
 </p>
 <p>{{ 'settings.monitoring.queued_tasks_explain' | translate }}</p>
 
+</meta name="description" content="settings monitoring indexing">
 <h2 translate="settings.monitoring.indexing"></h2>
 {{ 'settings.monitoring.indexing_info' | translate }}
 <div class="mt-10">
@@ -13,6 +21,7 @@
   <span class="text-danger" ng-show="reindexingStarted"><strong>{{ 'settings.monitoring.reindexing_started' | translate }}</strong></span>
 </div>
 
+</meta name="description" content="settings monitoring server logs">
 <h2 translate="settings.monitoring.server_logs"></h2>
 <table class="table table-hover table-logs">
   <thead>


### PR DESCRIPTION
resolves #160 
- modified index.html, settings.config.html, settings.html, and settings.monitoring.html to add header with meta description to increase SEO score on Lighthouse
- SEO score improves by 9% 
<img width="940" alt="Screen Shot 2022-09-06 at 10 19 57 AM" src="https://user-images.githubusercontent.com/53051688/188660572-f7bee28b-8b75-4e50-8a9a-91f9919cbb70.png">

