### PR TITLE
Resolves #58: Darken text to improve contrast ratio

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -172,7 +172,7 @@
     </div>
 
     <div class="row" ng-controller="Footer">
-      <div class="col-md-12 footer text-center text-muted small">
+      <div class="col-md-12 footer text-center small">
         <div class="alert alert-danger" ng-show="app.global_storage_quota && app.global_storage_quota * 0.8 < app.global_storage_current"
              translate="index.global_quota_warning"
              translate-values="{ current: app.global_storage_current / 1000000, percent: app.global_storage_current / app.global_storage_quota * 100, total: app.global_storage_quota / 1000000 }">

--- a/docs-web/src/main/webapp/src/partial/docs/login.html
+++ b/docs-web/src/main/webapp/src/partial/docs/login.html
@@ -22,7 +22,7 @@
   /* Smaller links everywhere on login */
   a {
     font-size: 90%;
-    color: #666;
+    color: black;
   }
 </style>
 <div class="row vertical-center">
@@ -54,7 +54,7 @@
                    ng-attr-placeholder="{{ 'login.validation_code' | translate }}" ng-model="user.code" />
           </div>
 
-          <div class="checkbox text-muted">
+          <div class="checkbox">
             <label>
               <input type="checkbox" ng-model="user.remember" name="remember" /> {{ 'login.remember_me' | translate }}
             </label>
@@ -62,7 +62,7 @@
 
           <div class="row">
             <div class="col-md-6">
-              <button type="submit" class="btn btn-primary" ng-click="login()">
+              <button type="submit" class="btn btn-dark" ng-click="login()">
                 <span class="fas fa-check"></span> {{ 'login.submit' | translate }}
               </button>
             </div>


### PR DESCRIPTION
Text and button colors were darkened to increase the contrast ratio between the white background and dark foreground objects. Some elements that were fixed include the 'Remember Me' label, 'Sign In' button, and the row of footer links. These were fixed by changing the text-muted class and adjusting the colors. 

The accessibility score improved by 3% from 86 to 89, after fixing all of the contrast issues. 
Resolves #58 
