### PR TITLE
Fix heading order accessibility by updating <h4> to <h2> when viewing an existing tag

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/directive.acledit.html
+++ b/docs-web/src/main/webapp/src/partial/docs/directive.acledit.html
@@ -19,7 +19,7 @@
   </table>
 
   <div ng-show="writable">
-    <h2>{{ 'directive.acledit.add_permission' | translate }}</h2>
+    <h4>{{ 'directive.acledit.add_permission' | translate }}</h4>
 
     <form name="aclForm" class="form-horizontal">
       <div class="form-group">

--- a/docs-web/src/main/webapp/src/partial/docs/directive.acledit.html
+++ b/docs-web/src/main/webapp/src/partial/docs/directive.acledit.html
@@ -19,7 +19,7 @@
   </table>
 
   <div ng-show="writable">
-    <h4>{{ 'directive.acledit.add_permission' | translate }}</h4>
+    <h2>{{ 'directive.acledit.add_permission' | translate }}</h2>
 
     <form name="aclForm" class="form-horizontal">
       <div class="form-group">


### PR DESCRIPTION
Resolves issue #203

Changed an h4 tag to an h2 tag so that the heading elements follow sequentially-descending order. 
This increased the accessibility score from 79 to 80.
 