### PR TITLE
Add meta description to settings/config pages. SEO score improved from 78 to 89

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html ng-app="docs">
   <head>
+    <meta name="description" content="Teedy is an open source, lightweight document management system for individuals and businesses."/>
     <title ng-bind-template="{{ pageTitle ? pageTitle : appName }}">Teedy</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/docs-web/src/main/webapp/src/partial/docs/settings.config.html
+++ b/docs-web/src/main/webapp/src/partial/docs/settings.config.html
@@ -1,3 +1,7 @@
+<head>
+  <meta name="description" content="Change teddy configuration here"/>
+</head>
+
 <h2>
   <span translate="settings.config.title_guest_access"></span>
   <span class="label" ng-class="{ 'label-success': app.guest_login, 'label-danger': !app.guest_login }">


### PR DESCRIPTION
By adding a meta description to "setting.config.html" and "index.html files", there was an improvement of the SEO score from 78 to 89.
