### PR TITLE
Resolve Issue #235 -- Improve DocumentResource importEml Branch Coverage

### DIFF
--- a/docs-web/pom.xml
+++ b/docs-web/pom.xml
@@ -180,6 +180,28 @@
         </resources>
 
         <plugins>
+          
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.8</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <!-- attached to Maven test phase -->
+              <execution>
+                <id>report</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
           <plugin>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-maven-plugin</artifactId>
@@ -188,6 +210,10 @@
                 <systemProperty>
                   <name>application.mode</name>
                   <value>dev</value>
+                </systemProperty>
+                <systemProperty>
+                  <name>docs.home</name>
+                  <value>/home/cisner/teedy/docs</value>
                 </systemProperty>
               </systemProperties>
               <webApp>


### PR DESCRIPTION
Resolve Issue #235. Adds unauthenticated user test to TestDocumentResource.java. Adds Jacoco plugin to pom.xml. Improved branch coverage for importEml under DocumentResource from 62% to 75% by covering one new unauthenticated user branch. Overall, DocumentResource coverage increased from 82% to 83%. 