### PR TITLE
Added an aria-label to color buttons on the tag and tag edit pages

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/tag.edit.html
+++ b/docs-web/src/main/webapp/src/partial/docs/tag.edit.html
@@ -23,7 +23,7 @@
       <div class="col-sm-2">
         <div class="input-group" id="inputColor" ng-class="{ 'has-error': !editTagForm.color.$valid && tagForm.$dirty }">
           <span colorpicker class="input-group-addon btn btn-default" data-color="#3a87ad" ng-model="tag.color" ng-style="{ 'background': tag.color }">&nbsp;</span>
-          <button class="btn btn-default" ng-click="hexaField = true" ng-show="!hexaField"><span class="fas fa-microchip"></span></button>
+          <button aria-label = "Enter new Hex color code for tag" class="btn btn-default" ng-click="hexaField = true" ng-show="!hexaField"><span class="fas fa-microchip"></span></button>
           <input type="text" name="color" class="form-control" ng-maxlength="7" ng-model="tag.color" ng-show="hexaField">
         </div>
       </div>

--- a/docs-web/src/main/webapp/src/partial/docs/tag.html
+++ b/docs-web/src/main/webapp/src/partial/docs/tag.html
@@ -17,7 +17,7 @@
         <div class="input-group" ng-class="{ 'has-error': !tagForm.color.$valid && tagForm.$dirty }">
           <span colorpicker class="input-group-addon btn btn-default" data-color="#3a87ad" ng-model="tag.color" ng-style="{ 'background': tag.color }">&nbsp;</span>
           <input type="text" name="color" class="form-control" ng-maxlength="7" ng-model="tag.color" ng-show="hexaField">
-          <button class="btn btn-default" ng-click="hexaField = true" ng-show="!hexaField"><span class="fas fa-microchip"></span></button>
+          <button  aria-label="Enter tag color Hex code" class="btn btn-default" ng-click="hexaField = true" ng-show="!hexaField"><span class="fas fa-microchip"></span></button>
         </div>
         <div class="form-group" ng-class="{ 'has-error': !tagForm.name.$valid && tagForm.$dirty }">
           <input type="text" name="name" ng-attr-placeholder="{{ 'tag.new_tag' | translate }}" class="form-control"


### PR DESCRIPTION
Added an aria-label to the color buttons in tag.html and tag.edit.html with a small summary. This improves the Accessibility score of the tag edit page from 77 to 84, and allows screen readers to summarize the function of the button. Here is a picture of the resulting lighthouse report. Resolves #246 

![Screen Shot 2022-09-07 at 4 53 56 PM](https://user-images.githubusercontent.com/111700944/188983765-bbed2b75-9d35-4a58-a8fb-bd38de40540d.jpg)
