### PR TITLE
Added new labels to buttons in order to increase accessibility 

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/document.default.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.default.html
@@ -21,7 +21,7 @@
         </a>
         <div class="file-info">
           <div class="v-align">
-            <button class="btn btn-danger" ng-click="deleteFile($event, file)"><span class="fas fa-trash"></span></button>
+            <button aria-label = "delete-file" class="btn btn-danger" ng-click="deleteFile($event, file)"><span class="fas fa-trash"></span></button>
           </div>
           <div class="v-align file-name" ng-if="file.name">{{ file.name }}</div>
           <div class="v-align">

--- a/docs-web/src/main/webapp/src/partial/docs/document.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.html
@@ -7,7 +7,7 @@
           <a href="#/document/add" class="btn btn-primary">
             <span class="fas fa-plus"></span> {{ 'document.add_document' | translate }}
           </a>
-          <button type="button" class="btn btn-primary" uib-dropdown-toggle>
+          <button aria-label = "add-doc-dropdown" type="button" class="btn btn-primary" uib-dropdown-toggle>
             <span class="caret"></span>
           </button>
           <ul uib-dropdown-menu>
@@ -194,14 +194,14 @@
           <span class="fas fa-chevron-up"></span>
         </button>
         <!-- Toggle navigation -->
-        <button class="btn btn-default" ng-click="navigationToggle()"
+        <button aria-label = "navigate-folder" class="btn btn-default" ng-click="navigationToggle()"
                 ng-class="{ active: navigationEnabled }"
                 uib-tooltip="{{ 'document.toggle_navigation' | translate }}"
                 tooltip-append-to-body="true">
           <span class="far" ng-class="{ 'fa-folder-open': navigationEnabled, 'fa-folder': !navigationEnabled }"></span>
         </button>
         <!-- Add a tag here -->
-        <button class="btn btn-primary btn-add-tag"
+        <button aria-label = "add-tag" class="btn btn-primary btn-add-tag"
                 uib-tooltip="{{ 'tag.new_tag' | translate }}"
                 ng-click="addTagHere()">
           <span>


### PR DESCRIPTION
Adds descriptive tags to 4 different buttons mentioned by lighthouse in order to improve the user accessibility. The score of the accessibility metric increased by 8 (69 -> 77) after the revision.
<img width="462" alt="Screen Shot 2022-09-08 at 1 36 47 AM" src="https://user-images.githubusercontent.com/71565937/189043173-311939e9-fd79-4bce-b7a4-6b69fa0869db.png">


Resolves #262 