### PR TITLE
Increasing Accessibility by increasing color contrast on login page

### DIFF
--- a/docs-web/pom.xml
+++ b/docs-web/pom.xml
@@ -189,6 +189,10 @@
                   <name>application.mode</name>
                   <value>dev</value>
                 </systemProperty>
+                <systemProperty>
+                  <name>docs.home</name>
+                  <value>/home/monkeyjerr/teedy/docs</value>
+                </systemProperty>
               </systemProperties>
               <webApp>
                 <contextPath>/</contextPath>

--- a/docs-web/src/main/webapp/src/partial/docs/login.html
+++ b/docs-web/src/main/webapp/src/partial/docs/login.html
@@ -22,7 +22,7 @@
   /* Smaller links everywhere on login */
   a {
     font-size: 90%;
-    color: #666;
+    color: rgb(0, 0, 0);
   }
 </style>
 <div class="row vertical-center">

--- a/docs-web/src/main/webapp/src/style/bootstrap.css
+++ b/docs-web/src/main/webapp/src/style/bootstrap.css
@@ -526,7 +526,7 @@ mark,
   text-transform: capitalize;
 }
 .text-muted {
-  color: #777;
+  color: #000;
 }
 .text-primary {
   color: #337ab7;

--- a/docs-web/src/main/webapp/src/style/main.less
+++ b/docs-web/src/main/webapp/src/style/main.less
@@ -563,7 +563,7 @@ input[readonly].share-link {
   }
 
   .btn-primary {
-    background-color: #2aabd2;
+    background-color: #14596e;
     border-color: transparent;
   }
 


### PR DESCRIPTION
Increased Accessibility score from 86 to 89 by darkening the color of the sign in button and the muted text on the login page, which increased the color contrast of the page. Resolves #277.