### PR TITLE
Fixes contrast ratios and increasing Accessibility on group page

### DIFF
--- a/docs-web/Users/neeju/Documents/Teedy/docs-web/log/docs.log
+++ b/docs-web/Users/neeju/Documents/Teedy/docs-web/log/docs.log
@@ -1,0 +1,11 @@
+07 Sep 2022 15:41:15,683 INFO com.sismics.util.jpa.EMF.getEntityManagerProperties(EMF.java:67) Configuring EntityManager from hibernate.properties 
+07 Sep 2022 15:41:23,971 INFO com.sismics.util.jpa.DbOpenHelper.open(DbOpenHelper.java:57) Opening database and executing incremental updates 
+07 Sep 2022 15:41:24,015 INFO com.sismics.util.jpa.DbOpenHelper.open(DbOpenHelper.java:106) Found database version 27, new version is 27, executing database incremental update scripts 
+07 Sep 2022 15:41:24,015 INFO com.sismics.util.jpa.DbOpenHelper.open(DbOpenHelper.java:108) Database upgrade complete 
+07 Sep 2022 15:41:24,020 INFO com.sismics.util.jpa.EMF.getEntityManagerProperties(EMF.java:67) Configuring EntityManager from hibernate.properties 
+07 Sep 2022 15:41:35,903 INFO com.sismics.util.ClasspathScanner.findClasses(ClasspathScanner.java:48) Found 1 classes for IndexingHandler 
+07 Sep 2022 15:41:36,302 INFO com.sismics.docs.core.util.indexing.LuceneIndexingHandler.initLucene(LuceneIndexingHandler.java:115) Using RAM Lucene storage 
+07 Sep 2022 15:41:37,650 INFO com.sismics.docs.core.service.FileService.startUp(FileService.java:39) File service starting up 
+07 Sep 2022 15:41:37,709 INFO com.sismics.docs.core.service.InboxService.startUp(InboxService.java:55) Inbox service starting up 
+07 Sep 2022 15:42:21,250 INFO com.sismics.docs.core.service.InboxService.shutDown(InboxService.java:60) Inbox service shutting down 
+07 Sep 2022 15:42:21,253 INFO com.sismics.docs.core.service.FileService.shutDown(FileService.java:44) File service shutting down 

--- a/docs-web/pom.xml
+++ b/docs-web/pom.xml
@@ -189,6 +189,10 @@
                   <name>application.mode</name>
                   <value>dev</value>
                 </systemProperty>
+                <systemProperty>
+                  <name>docs.home</name>
+                  <value>/home/neerajr/teedy/docs/</value>  
+                </systemProperty>
               </systemProperties>
               <webApp>
                 <contextPath>/</contextPath>

--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -127,7 +127,7 @@
 
         <a class="navbar-brand" href="#">
           <span ng-if="appName == 'Teedy'">
-            <span style="color: #2aabd2;">teedy</span>
+            <span style="color: #29658c;">teedy</span>
           </span>
           <span ng-if="appName != 'Teedy'" style="color: #888;">{{ appName }}</span>
         </a>

--- a/docs-web/src/main/webapp/src/style/bootstrap.css
+++ b/docs-web/src/main/webapp/src/style/bootstrap.css
@@ -526,7 +526,7 @@ mark,
   text-transform: capitalize;
 }
 .text-muted {
-  color: #777;
+  color: rgb(70, 69, 69);
 }
 .text-primary {
   color: #337ab7;


### PR DESCRIPTION
Was able to increase the Accessibility score from 86 to 88 after darkening the teedy logo in the top left corner of the page and by darkening the muted text on the bottom of the page as well. This was able to improve the contrast ratio enough to improve the accessibility of the page.