### PR TITLE
Added aria-labels to the buttons on the documents page 

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/document.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.html
@@ -7,7 +7,7 @@
           <a href="#/document/add" class="btn btn-primary">
             <span class="fas fa-plus"></span> {{ 'document.add_document' | translate }}
           </a>
-          <button type="button" class="btn btn-primary" uib-dropdown-toggle>
+          <button type="button" class="btn btn-primary" aria-label="dropdown toggle" uib-dropdown-toggle>
             <span class="caret"></span>
           </button>
           <ul uib-dropdown-menu>
@@ -197,13 +197,15 @@
         <button class="btn btn-default" ng-click="navigationToggle()"
                 ng-class="{ active: navigationEnabled }"
                 uib-tooltip="{{ 'document.toggle_navigation' | translate }}"
-                tooltip-append-to-body="true">
+                tooltip-append-to-body="true"
+                aria-label="toggle folder navigation">
           <span class="far" ng-class="{ 'fa-folder-open': navigationEnabled, 'fa-folder': !navigationEnabled }"></span>
         </button>
         <!-- Add a tag here -->
         <button class="btn btn-primary btn-add-tag"
                 uib-tooltip="{{ 'tag.new_tag' | translate }}"
-                ng-click="addTagHere()">
+                ng-click="addTagHere()"
+                aria-label="add tag">
           <span>
             <i class="fas fa-tag"></i>
             <i class="fas fa-plus"></i>


### PR DESCRIPTION
Cleared the three failing elements proposed by Lighthouse under the warning "Buttons do not have an accessible name"; added aria-labels to the "dropdown toggle", "toggle folder navigation", and "add tag" buttons on the Documents page (reflected in the file document.html). This warning is now gone from the Lighthouse audit, and the Accessibility score improved by 6 points, from 80 to 86 on a 27'' monitor screen. resolves #273.