### PR TITLE
Resolves #69: added meta descriptions to index.html in docs-web source

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -3,6 +3,8 @@
   <head>
     <title ng-bind-template="{{ pageTitle ? pageTitle : appName }}">Teedy</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <!-- Adding meta descriptions to improve SEO -->
+    <meta name="description" content="Teedy is an open source, lightweight document management system for individuals and businesses."/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="renderer" content="webkit" />


### PR DESCRIPTION
This pull request Resolves #69 by adding a meta description to the entire site. To do this, I went to docs-web/source/main/webapp/src/index.html and added the html meta description. I wanted to make sure the description I used was best for SEO, so I took keywords such as open-source and document management to correctly describe the site. This would improve SEO score because when Teedy is search for on a search engine, the user would be able to see a short description of the site and searches would be able to identify and rank Teedy better. The meta description was implemented by:

`<meta name="description" content="Teedy is an open source, lightweight document management platform for individuals and businesses">`

Since implementing this change, the SEO score has increased from 78 to 89. Since the codebase uses partials for rendering its webpage, I am unable to add meta descriptions to each individual page. However, by adding a meta description to the entire site, all pages, including Users and Groups, were able to improve in SEO score.