### PR TITLE
uses hidden attribute instead of aria-hidden

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -133,18 +133,20 @@
         </a>
       </div>
 
-      <div class="collapse navbar-collapse" uib-collapse="isCollapsed">
-        <ul class="nav navbar-nav" ng-show="!userInfo.anonymous">
-          <li ui-sref-active="{ active: 'document.**' }">
-            <a href="#/document"><span class="fas fa-book"></span> {{ 'index.nav_documents' | translate }}</a>
-          </li>
-          <li ui-sref-active="{ active: 'tag.**' }" id="navigation-tag">
-            <a href="#/tag"><span class="fas fa-tags"></span> {{ 'index.nav_tags' | translate }}</a>
-          </li>
-          <li ui-sref-active="{ active: 'user.**', active2: 'group.**' }">
-            <a href="#/user"><span class="fas fa-user"></span> {{ 'index.nav_users_groups' | translate }}</a>
-          </li>
-        </ul>
+      <p hidden>
+        <div class="collapse navbar-collapse" uib-collapse="isCollapsed">
+          <ul class="nav navbar-nav" ng-show="!userInfo.anonymous">
+            <li ui-sref-active="{ active: 'document.**' }">
+              <a href="#/document"><span class="fas fa-book"></span> {{ 'index.nav_documents' | translate }}</a>
+            </li>
+            <li ui-sref-active="{ active: 'tag.**' }" id="navigation-tag">
+              <a href="#/tag"><span class="fas fa-tags"></span> {{ 'index.nav_tags' | translate }}</a>
+            </li>
+            <li ui-sref-active="{ active: 'user.**', active2: 'group.**' }">
+              <a href="#/user"><span class="fas fa-user"></span> {{ 'index.nav_users_groups' | translate }}</a>
+            </li>
+          </ul>
+      </p>
 
         <ul class="nav navbar-nav navbar-right" ng-show="!userInfo.anonymous">
           <li>

--- a/docs-web/src/main/webapp/src/lib/angular.ui-bootstrap.js
+++ b/docs-web/src/main/webapp/src/lib/angular.ui-bootstrap.js
@@ -106,8 +106,8 @@ angular.module('ui.bootstrap.collapse', [])
                 // prevents the animation from jumping to collapsed state
                 .removeClass('collapse')
                 .addClass('collapsing')
-                .attr('aria-expanded', false)
-                .attr('aria-hidden', true);
+                .attr('aria-expanded', false);
+                // .attr('aria-hidden', true);
 
               if ($animateCss) {
                 $animateCss(element, {


### PR DESCRIPTION
Resolves #297 by using a hidden attribute instead of changing the aria-hidden attribute for the navigation bar. This way, all the focusable descendents cannot be seen (as they shouldn't be). The score increased from 80 -> 82