### PR TITLE
Added Aria-label to Tag.html Button

### DIFF
--- a/docs-web/src/main/webapp/src/partial/docs/tag.html
+++ b/docs-web/src/main/webapp/src/partial/docs/tag.html
@@ -17,7 +17,7 @@
         <div class="input-group" ng-class="{ 'has-error': !tagForm.color.$valid && tagForm.$dirty }">
           <span colorpicker class="input-group-addon btn btn-default" data-color="#3a87ad" ng-model="tag.color" ng-style="{ 'background': tag.color }">&nbsp;</span>
           <input type="text" name="color" class="form-control" ng-maxlength="7" ng-model="tag.color" ng-show="hexaField">
-          <button class="btn btn-default" ng-click="hexaField = true" ng-show="!hexaField"><span class="fas fa-microchip"></span></button>
+          <button class="btn btn-default" ng-click="hexaField = true" ng-show="!hexaField" aria-label="Change Tag Color"><span class="fas fa-microchip"></span></button>
         </div>
         <div class="form-group" ng-class="{ 'has-error': !tagForm.name.$valid && tagForm.$dirty }">
           <input type="text" name="name" ng-attr-placeholder="{{ 'tag.new_tag' | translate }}" class="form-control"


### PR DESCRIPTION
Resolves #304 

A "btn btn-default" class button had no accessible name, so some screen readers or other technologies will only announce the button as _button_ but not describe what it does. 
I added an aria-label to the button describe what is does to people using assistive technology.
The Accessibility score by lighthouse improved from 86 points to 95 points.