### PR TITLE
fixed font sizes to have legible font size(>=12px)

### DIFF
--- a/docs-web/src/main/webapp/src/style/bootstrap.css
+++ b/docs-web/src/main/webapp/src/style/bootstrap.css
@@ -272,7 +272,7 @@ th {
           box-sizing: border-box;
 }
 html {
-  font-size: 10px;
+  font-size: 12px;
 
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
@@ -452,7 +452,7 @@ h5 .small,
 .h5 .small,
 h6 .small,
 .h6 .small {
-  font-size: 75%;
+  font-size: 90%;
 }
 h1,
 .h1 {
@@ -494,7 +494,7 @@ p {
 }
 small,
 .small {
-  font-size: 85%;
+  font-size: 90%;
 }
 mark,
 .mark {


### PR DESCRIPTION
Fixed font sizes to have legible font size(>=12px) -> Resolves #301  
The SEO score increased from 65 to 72.
- Every font sizes that were below 12 were fixed to 12px
- Font sizes that were shown in percentages that were below 90% were also changed to 90% 
![before](https://user-images.githubusercontent.com/112718895/189239996-32d0d10b-ccda-4bb4-86fc-b216d5d47c51.PNG)
![after](https://user-images.githubusercontent.com/112718895/189240005-cb6fcc43-e8b2-45e5-9353-32370efd61ea.PNG)
