### PR TITLE
Resolves #325

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -116,7 +116,7 @@
 
     <nav class="navbar navbar-default" role="navigation" ng-controller="Navigation">
       <div class="navbar-header">
-        <button type="button" class="navbar-toggle"
+        <button type="button" aria-label="Navbar Dropdown" class="navbar-toggle"
                 ng-init="isCollapsed = true"
                 ng-click="isCollapsed = !isCollapsed">
           <span class="sr-only">{{ 'index.toggle_navigation' | translate }}</span>

--- a/docs-web/src/main/webapp/src/partial/docs/document.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.html
@@ -7,7 +7,7 @@
           <a href="#/document/add" class="btn btn-primary">
             <span class="fas fa-plus"></span> {{ 'document.add_document' | translate }}
           </a>
-          <button type="button" class="btn btn-primary" uib-dropdown-toggle>
+          <button type="button" aria-label="Document Dropdown" class="btn btn-primary" uib-dropdown-toggle>
             <span class="caret"></span>
           </button>
           <ul uib-dropdown-menu>
@@ -197,13 +197,15 @@
         <button class="btn btn-default" ng-click="navigationToggle()"
                 ng-class="{ active: navigationEnabled }"
                 uib-tooltip="{{ 'document.toggle_navigation' | translate }}"
-                tooltip-append-to-body="true">
+                tooltip-append-to-body="true"
+                aria-label="Toggle Folder Navigation">
           <span class="far" ng-class="{ 'fa-folder-open': navigationEnabled, 'fa-folder': !navigationEnabled }"></span>
         </button>
         <!-- Add a tag here -->
         <button class="btn btn-primary btn-add-tag"
                 uib-tooltip="{{ 'tag.new_tag' | translate }}"
-                ng-click="addTagHere()">
+                ng-click="addTagHere()"
+                aria-label="New Tag">
           <span>
             <i class="fas fa-tag"></i>
             <i class="fas fa-plus"></i>


### PR DESCRIPTION
Changes fixes issue #325 by adding aria labels to each button on the Documents page. The 4 buttons were:

Navbar dropdown (now labeled "Navbar Dropdown")

Documents dropdown (now labeled "Document Dropdown")

Folder navigation toggle (now labeled "Toggle Folder Navigation")

New tag (now labeled "New Tag")

These changes improved the accessibility score from 82 to 86 on Lighthouse.